### PR TITLE
Swap experience and education sections; close sidebar on link click in mobile view

### DIFF
--- a/assets/js/nav.js
+++ b/assets/js/nav.js
@@ -14,6 +14,21 @@ on(
   true
 );
 
+// Close on link click
+on(
+  'click',
+  '#navbar .nav-link',
+  function () {
+    if (document.body.classList.contains('mobile-nav-active')) {
+      document.body.classList.remove('mobile-nav-active');
+      const toggle = select('.mobile-nav-toggle');
+      toggle.classList.add('bi-list');
+      toggle.classList.remove('bi-x');
+    }
+  },
+  true
+);
+
 // Back-to-top button
 let backToTop = select('.back-to-top');
 if (backToTop) {

--- a/index.html
+++ b/index.html
@@ -38,9 +38,9 @@ title: 'Fabrizio Miano, PhD | Resume'
             microelectronics and supply chain dynamics.
           </p>
           <p class="mb-3">
-            Previously, a Senior Data Quality Analyst at Coca-Cola HBC, responsible for business-led
+            Previously, a Sr Data Quality Analyst at Coca-Cola HBC, responsible for business-led
             data governance initiatives to ensure high data quality across the value chain. Also
-            served as a Senior Consultant and Team Leader for Capgemini, leading international agile
+            served as a Sr Consultant and Team Leader for Capgemini, leading international agile
             projects for STMicroelectronics. Past roles include data-science consulting for public
             administration and defense clients, post-doctoral research at the University of Sussex
             in data science, and a junior data scientist position with a focus on computer vision.
@@ -315,72 +315,47 @@ title: 'Fabrizio Miano, PhD | Resume'
       </div>
 
       <div class="row">
-        <!-- Education  -->
-        <div class="col-lg-6" data-aos="fade-up">
-          <h3 class="resume-title">Education</h3>
-          <div class="resume-item">
-            <h4>PhD in Physics</h4>
-            <h5>2015 - 2018</h5>
-            <p>
-              <em>University of Sussex</em><i class="me-2 fas fa-map-marker-alt ms-1"></i>Brighton,
-              UK
-            </p>
-            <p>
-              “Optimisation studies and data-driven background estimation in searches for the
-              supersymmetric partner of the top quark with the ATLAS Detector at the LHC”. 2018.
-              <a href="http://cds.cern.ch/record/2650559" target="_blank"
-                >http://cds.cern.ch/record/2650559</a
-              >
-            </p>
-          </div>
-
-          <div class="resume-item">
-            <h4>MSC in Physics</h4>
-            <h5>2009 - 2014</h5>
-            <p>
-              <em>Università di Catania</em><i class="me-2 fas fa-map-marker-alt ms-1"></i>Catania,
-              Italy
-            </p>
-            <p>
-              “Emissione di protoni e caratterizzazione spazio-temporale in collisioni tra ioni
-              pesanti”.
-            </p>
-          </div>
-
-          <div class="resume-item">
-            <h4>BSc in Physics</h4>
-            <h5>2005 - 2009</h5>
-            <p>
-              <em>Università di Catania</em><i class="me-2 fas fa-map-marker-alt ms-1"></i>Catania,
-              Italy
-            </p>
-            <p>“Spettri di neutroni in sorgenti standard <em>Am/Be</em> e <em>Pu/Be</em>”.</p>
-          </div>
-        </div>
-
         <!-- Professional experience -->
         <div class="col-lg-6" data-aos="fade-up" data-aos-delay="100">
           <h3 class="resume-title">Professional Experience</h3>
+
           <div class="resume-item">
-            <h4>Senior Business Advisor</h4>
+            <h4>Sr Business Advisor</h4>
             <h6>
               <i class="fas fa-building"></i> STMicroelectronics
               <i class="me-2 fas fa-map-marker-alt ms-1"></i><em>Catania, Italy</em>
             </h6>
-            <h5>2024/06 - Current</h5>
+            <h5>2024/06 - 2025/01</h5>
             <ul>
-              Developing an in-depth understanding of STMicroelectronics' products, services, and
-              strategic objectives; Monitoring and analyzing supply chain data to identify and
-              address bottlenecks; Collaborating with the supply chain team to align sales,
-              marketing, and product availability; Designing and maintaining analytical tools and
-              dashboards for KPI tracking; Utilizing scripting and programming skills to automate
-              tasks and support Sales, Marketing, and Operations teams; Serving as a liaison between
-              divisions to ensure accurate information sharing;
+              Within the context of Sales and Marketing, the focus is on: Developing an in-depth
+              understanding of STMicroelectronics' products, services, and strategic objectives;
+              Monitoring and analyzing supply chain data to identify and address bottlenecks;
+              Collaborating with the supply chain team to align sales, marketing, and product
+              availability; Designing and maintaining analytical tools and dashboards for KPI
+              tracking; Utilizing scripting and programming skills to automate tasks and support
+              Sales, Marketing, and Operations teams; Serving as a liaison between divisions to
+              ensure accurate information sharing;
             </ul>
           </div>
 
           <div class="resume-item">
-            <h4>Senior Data Quality Analyst</h4>
+            <h4>Business Operations Support PM</h4>
+            <h6>
+              <i class="fas fa-building"></i> STMicroelectronics
+              <i class="me-2 fas fa-map-marker-alt ms-1"></i><em>Catania, Italy</em>
+            </h6>
+            <h5>2024/06 - 2025/01</h5>
+            <ul>
+              I managed small data projects aimed at supporting data-driven decision-making
+              processes, enhancing operational efficiency. My responsibilities included data
+              understanding, collection, modelling, designing and developing analytical dashboards,
+              automating processes, and collaborating with various teams to support strategic
+              initiatives.
+            </ul>
+          </div>
+
+          <div class="resume-item">
+            <h4>Sr Data Analyst</h4>
             <h6>
               <i class="fas fa-building"></i> Coca-Cola HBC
               <i class="me-2 fas fa-map-marker-alt ms-1"></i><em>Remote, Italy</em>
@@ -400,14 +375,14 @@ title: 'Fabrizio Miano, PhD | Resume'
           </div>
 
           <div class="resume-item">
-            <h4>Senior Consultant</h4>
+            <h4>Sr Consultant</h4>
             <h6>
               <i class="fas fa-building"></i> Capgemini
               <i class="me-2 fas fa-map-marker-alt ms-1"></i><em>Remote, Italy</em>
             </h6>
             <h5>2020/09 - 2023/05</h5>
             <ul>
-              Senior Consultant and Team Leader in an international agile project focused on the
+              Sr Consultant and Team Leader in an international agile project focused on the
               delivery of an end-to-end business intelligence solution to explore customer demand
               and demand planning forecast analytics. The solution is fully developed on the Azure
               stack. DevOps and versioning best-practice: CI/CD with Jenkins and Terraform; code
@@ -465,6 +440,49 @@ title: 'Fabrizio Miano, PhD | Resume'
               Development of a statistical tool to select interesting images within a dataset;
               Design of a ML tool to classify grey sky and sunset images
             </ul>
+          </div>
+        </div>
+
+        <!-- Education  -->
+        <div class="col-lg-6" data-aos="fade-up">
+          <h3 class="resume-title">Education</h3>
+          <div class="resume-item">
+            <h4>PhD in Physics</h4>
+            <h5>2015 - 2018</h5>
+            <p>
+              <em>University of Sussex</em><i class="me-2 fas fa-map-marker-alt ms-1"></i>Brighton,
+              UK
+            </p>
+            <p>
+              “Optimisation studies and data-driven background estimation in searches for the
+              supersymmetric partner of the top quark with the ATLAS Detector at the LHC”. 2018.
+              <a href="http://cds.cern.ch/record/2650559" target="_blank"
+                >http://cds.cern.ch/record/2650559</a
+              >
+            </p>
+          </div>
+
+          <div class="resume-item">
+            <h4>MSC in Physics</h4>
+            <h5>2009 - 2014</h5>
+            <p>
+              <em>Università di Catania</em><i class="me-2 fas fa-map-marker-alt ms-1"></i>Catania,
+              Italy
+            </p>
+            <p>
+              “Emissione di protoni e caratterizzazione spazio-temporale in collisioni tra ioni
+              pesanti”.
+            </p>
+          </div>
+
+          <div class="resume-item">
+            <h4>BSc in Physics</h4>
+            <h5>2005 - 2009</h5>
+            <p>
+              <em>Università di Catania</em><i class="me-2 fas fa-map-marker-alt ms-1"></i>Catania,
+              Italy
+            </p>
+            <p>“Spettri di neutroni in sorgenti standard <em>Am/Be</em> e <em>Pu/Be</em>”.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Reorganize the resume layout by swapping the experience and education sections. Implement a feature to close the sidebar when a link is clicked in mobile view for improved navigation.